### PR TITLE
[FEATURE] Implement Add habit modal

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -428,6 +428,8 @@ PODS:
     - React-jsi (= 0.71.6)
     - React-logger (= 0.71.6)
     - React-perflogger (= 0.71.6)
+  - RNGestureHandler (2.9.0):
+    - React-Core
   - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
@@ -501,6 +503,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -599,6 +602,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNVectorIcons:
@@ -658,6 +663,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 73d201599a64ea14b4e0b8f91b64970979fd92e6
   React-runtimeexecutor: 8692ac548bec648fa121980ccb4304afd136d584
   ReactCommon: 0c43eaeaaee231d7d8dc24fc5a6e4cf2b75bf196
+  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   SimpleKeychain: 130211269f88f038d7dc5254cf0b1b9ce978c398

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-native": "0.71.6",
         "react-native-auth0": "^2.17.1",
         "react-native-dotenv": "^3.4.8",
+        "react-native-gesture-handler": "^2.9.0",
         "react-native-paper": "^5.7.0",
         "react-native-safe-area-context": "^4.5.1",
         "react-native-screens": "^3.20.0",
@@ -2215,7 +2216,6 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -5316,8 +5316,7 @@
     "node_modules/@types/hammerjs": {
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
-      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
-      "peer": true
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -15223,7 +15222,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
       "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -19142,7 +19140,6 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "peer": true,
       "requires": {
         "@types/hammerjs": "^2.0.36"
       }
@@ -21480,8 +21477,7 @@
     "@types/hammerjs": {
       "version": "2.0.41",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
-      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
-      "peer": true
+      "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -28884,7 +28880,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz",
       "integrity": "sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==",
-      "peer": true,
       "requires": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-native": "0.71.6",
     "react-native-auth0": "^2.17.1",
     "react-native-dotenv": "^3.4.8",
+    "react-native-gesture-handler": "^2.9.0",
     "react-native-paper": "^5.7.0",
     "react-native-safe-area-context": "^4.5.1",
     "react-native-screens": "^3.20.0",

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -4,6 +4,7 @@ export const ACTIONS = {
   SET_ALL_HABITS: 'SET_ALL_HABITS',
   TOGGLE_HABIT_IS_COMPLETED: 'TOGGLE_HABIT_IS_COMPLETED',
   HANDLE_LOGOUT: 'HANDLE_LOGOUT',
+  ADD_HABIT: 'ADD_HABIT',
 } as const;
 
 type Action = {
@@ -21,6 +22,9 @@ export const reducer = (state: State, action: Action) => {
       // action.payload should be an array of habits
       // TODO: add some validation here
       return {...state, habits: action.payload};
+    case ACTIONS.ADD_HABIT:
+      // action.payload should be a habit
+      return {...state, habits: [...state.habits, action.payload]};
     case ACTIONS.HANDLE_LOGOUT:
       return {...state, habits: []};
     case ACTIONS.TOGGLE_HABIT_IS_COMPLETED: {

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -113,11 +113,11 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.pop()}>
-          <Text style={styles.discard}>Discard</Text>
+          <Text style={styles.discard}>{LABEL.DISCARD}</Text>
         </TouchableOpacity>
-        <Text variant="titleMedium">Add Habit</Text>
+        <Text variant="titleMedium">{LABEL.CREATE_HABIT}</Text>
         <TouchableOpacity onPress={handleCreateHabit}>
-          <Text style={styles.create}>Create</Text>
+          <Text style={styles.create}>{LABEL.CREATE}</Text>
         </TouchableOpacity>
       </View>
       <View style={styles.content}>
@@ -133,7 +133,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
           />
           <TextInput
             style={styles.textInput}
-            placeholder="Habit name"
+            placeholder={LABEL.HABIT_NAME}
             onChangeText={text => {
               setName(text);
             }}

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -1,17 +1,11 @@
 import React, {useCallback, useState} from 'react';
-import {
-  StyleSheet,
-  View,
-  TouchableOpacity,
-  TextInput,
-  TouchableWithoutFeedback,
-} from 'react-native';
+import {StyleSheet, View, TouchableOpacity, TextInput} from 'react-native';
 import {Text, IconButton} from 'react-native-paper';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {WeekdayPicker} from './WeekdayPicker';
 import {useFocusEffect} from '@react-navigation/native';
 import {LABEL} from '@app/language';
+import {themeColors} from '@app/theme';
 
 interface AddHabitModalProps {
   navigation: any;
@@ -61,10 +55,12 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <TouchableOpacity onPress={() => navigation.pop()}>
-          <MaterialIcons name="close" size={24} color="black" />
+          <Text style={styles.discard}>Discard</Text>
         </TouchableOpacity>
         <Text variant="titleMedium">Add Habit</Text>
-        <View style={{width: 24}} />
+        <TouchableOpacity onPress={handleCreateHabit}>
+          <Text style={styles.create}>Create</Text>
+        </TouchableOpacity>
       </View>
       <View style={styles.content}>
         <View style={styles.row}>
@@ -86,16 +82,6 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
             });
           }}
         />
-        <View style={styles.footer}>
-          <TouchableWithoutFeedback onPress={() => navigation.pop()}>
-            <Text style={styles.discard}>Discard</Text>
-          </TouchableWithoutFeedback>
-          <TouchableOpacity
-            style={styles.createHabitButton}
-            onPress={handleCreateHabit}>
-            <Text style={styles.createHabitButtonText}>Create Habit</Text>
-          </TouchableOpacity>
-        </View>
       </View>
     </SafeAreaView>
   );
@@ -134,24 +120,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     paddingLeft: 8,
   },
-  footer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 16,
-  },
   discard: {
     fontSize: 16,
-    color: 'red',
+    color: themeColors.red[600],
   },
-  createHabitButton: {
-    backgroundColor: 'blue',
-    paddingHorizontal: 24,
-    paddingVertical: 8,
-    borderRadius: 5,
-  },
-  createHabitButtonText: {
+  create: {
     fontSize: 16,
-    color: 'white',
+    color: themeColors.blue[600],
   },
 });

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useState} from 'react';
-import {StyleSheet, View, TouchableOpacity, TextInput} from 'react-native';
-import {Text, IconButton} from 'react-native-paper';
+import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {Text, IconButton, TextInput} from 'react-native-paper';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {WeekdayPicker} from './WeekdayPicker';
 import {useFocusEffect} from '@react-navigation/native';
@@ -64,7 +64,13 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
       </View>
       <View style={styles.content}>
         <View style={styles.row}>
-          <IconButton icon={icon} onPress={handleIconPress} />
+          <IconButton
+            style={styles.iconButton}
+            icon={icon}
+            onPress={handleIconPress}
+            mode={'contained'}
+            size={42}
+          />
           <TextInput
             style={styles.textInput}
             placeholder="Habit name"
@@ -106,19 +112,22 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     paddingHorizontal: 16,
-    paddingVertical: 8,
+    paddingVertical: 16,
+  },
+  iconButton: {
+    marginRight: 16,
+    marginLeft: 0,
   },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 16,
+    justifyContent: 'space-between',
+    marginTop: 16,
+    marginBottom: 32,
   },
   textInput: {
     flex: 1,
-    borderBottomWidth: 1,
-    borderBottomColor: 'gray',
     fontSize: 16,
-    paddingLeft: 8,
   },
   discard: {
     fontSize: 16,

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {StyleSheet, Text, View, TouchableOpacity} from 'react-native';
+import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {Text} from 'react-native-paper';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 
@@ -14,7 +15,7 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({navigation}) => {
         <TouchableOpacity onPress={() => navigation.pop()}>
           <MaterialIcons name="close" size={24} color="black" />
         </TouchableOpacity>
-        <Text style={styles.title}>Add Habit</Text>
+        <Text variant="titleMedium">Add Habit</Text>
         <View style={{width: 24}} />
       </View>
       <View style={styles.content}>{/* Add content here */}</View>
@@ -37,10 +38,6 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderBottomColor: 'lightgray',
     borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  title: {
-    fontWeight: 'bold',
-    fontSize: 18,
   },
   content: {
     flex: 1,

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -1,14 +1,62 @@
-import React from 'react';
-import {StyleSheet, View, TouchableOpacity} from 'react-native';
-import {Text} from 'react-native-paper';
+import React, {useCallback, useState} from 'react';
+import {
+  StyleSheet,
+  View,
+  TouchableOpacity,
+  TextInput,
+  TouchableWithoutFeedback,
+} from 'react-native';
+import {Text, IconButton} from 'react-native-paper';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import {WeekdayPicker} from './WeekdayPicker';
+import {useFocusEffect} from '@react-navigation/native';
+import {LABEL} from '@app/language';
 
 interface AddHabitModalProps {
   navigation: any;
+  route: any;
 }
 
-export const AddHabitModal: React.FC<AddHabitModalProps> = ({navigation}) => {
+export const AddHabitModal: React.FC<AddHabitModalProps> = ({
+  navigation,
+  route,
+}) => {
+  const [name, setName] = useState('');
+  const [icon, setIcon] = useState('image'); // default icon is image
+  const [selectedDays, setSelectedDays] = useState([
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+  ]);
+
+  // when this modal is focused again, check if iconName is passed in params
+  // if it is, set the icon to the iconName
+  useFocusEffect(
+    useCallback(() => {
+      const iconName = route.params?.iconName;
+      if (iconName) {
+        setIcon(iconName);
+      }
+    }, [route]),
+  );
+
+  const handleIconPress = () => {
+    navigation.navigate(LABEL.HABITS_STACK, {screen: LABEL.PICK_ICON_MODAL});
+  };
+
+  const handleCreateHabit = () => {
+    console.log({
+      name,
+      icon,
+      selectedDays,
+    });
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
@@ -18,7 +66,37 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({navigation}) => {
         <Text variant="titleMedium">Add Habit</Text>
         <View style={{width: 24}} />
       </View>
-      <View style={styles.content}>{/* Add content here */}</View>
+      <View style={styles.content}>
+        <View style={styles.row}>
+          <IconButton icon={icon} onPress={handleIconPress} />
+          <TextInput
+            style={styles.textInput}
+            placeholder="Habit name"
+            onChangeText={setName}
+            value={name}
+          />
+        </View>
+        <WeekdayPicker
+          selectedDays={selectedDays}
+          onDayPress={index => {
+            setSelectedDays(days => {
+              const newDays = [...days];
+              newDays[index] = !newDays[index];
+              return newDays;
+            });
+          }}
+        />
+        <View style={styles.footer}>
+          <TouchableWithoutFeedback onPress={() => navigation.pop()}>
+            <Text style={styles.discard}>Discard</Text>
+          </TouchableWithoutFeedback>
+          <TouchableOpacity
+            style={styles.createHabitButton}
+            onPress={handleCreateHabit}>
+            <Text style={styles.createHabitButtonText}>Create Habit</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
     </SafeAreaView>
   );
 };
@@ -43,5 +121,37 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingHorizontal: 16,
     paddingVertical: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  textInput: {
+    flex: 1,
+    borderBottomWidth: 1,
+    borderBottomColor: 'gray',
+    fontSize: 16,
+    paddingLeft: 8,
+  },
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  discard: {
+    fontSize: 16,
+    color: 'red',
+  },
+  createHabitButton: {
+    backgroundColor: 'blue',
+    paddingHorizontal: 24,
+    paddingVertical: 8,
+    borderRadius: 5,
+  },
+  createHabitButtonText: {
+    fontSize: 16,
+    color: 'white',
   },
 });

--- a/src/features/habits/components/AddHabit/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabit/AddHabitModal.tsx
@@ -2,10 +2,12 @@ import React, {useCallback, useState} from 'react';
 import {StyleSheet, View, TouchableOpacity} from 'react-native';
 import {Text, IconButton, TextInput} from 'react-native-paper';
 import {SafeAreaView} from 'react-native-safe-area-context';
-import {WeekdayPicker} from './WeekdayPicker';
 import {useFocusEffect} from '@react-navigation/native';
+
+import {WeekdayPicker} from './WeekdayPicker';
 import {LABEL} from '@app/language';
 import {themeColors} from '@app/theme';
+import {useStore, ACTIONS} from '@app/context/StoreContext';
 
 interface AddHabitModalProps {
   navigation: any;
@@ -28,6 +30,9 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
     true,
   ]);
 
+  const {state, dispatch} = useStore();
+  const {habits} = state;
+
   // when this modal is focused again, check if iconName is passed in params
   // if it is, set the icon to the iconName
   useFocusEffect(
@@ -44,11 +49,30 @@ export const AddHabitModal: React.FC<AddHabitModalProps> = ({
   };
 
   const handleCreateHabit = () => {
-    console.log({
+    const newHabit = {
+      id: habits.length + 1,
       name,
-      icon,
-      selectedDays,
+      iconName: icon,
+      colour: 'rgb(66, 135, 245)',
+      isCompleted: false,
+      completionPercentage: 0,
+      status: 'active',
+      daysDue: selectedDays
+        .map((day, index) => {
+          if (day) {
+            return index + 1;
+          }
+        })
+        .filter(day => day !== undefined),
+      completionHistory: [],
+    };
+
+    dispatch({
+      type: ACTIONS.ADD_HABIT,
+      payload: newHabit,
     });
+
+    navigation.pop();
   };
 
   return (

--- a/src/features/habits/components/AddHabit/PickIconModal.tsx
+++ b/src/features/habits/components/AddHabit/PickIconModal.tsx
@@ -5,6 +5,7 @@ import {SafeAreaView} from 'react-native-safe-area-context';
 import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import {LABEL} from '@app/language';
+import {themeColors} from '@app/theme';
 
 const icons = ['run', 'water', 'fire', 'music', 'soccer'];
 
@@ -76,7 +77,7 @@ const styles = StyleSheet.create({
   },
   select: {
     fontSize: 16,
-    color: 'blue',
+    color: themeColors.blue[600],
   },
   iconContainer: {
     flexDirection: 'row',

--- a/src/features/habits/components/AddHabit/PickIconModal.tsx
+++ b/src/features/habits/components/AddHabit/PickIconModal.tsx
@@ -1,0 +1,97 @@
+import React, {useState} from 'react';
+import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {Text} from 'react-native-paper';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import {LABEL} from '@app/language';
+
+const icons = ['run', 'water', 'fire', 'music', 'soccer'];
+
+interface PickIconModalProps {
+  navigation: any;
+}
+
+export const PickIconModal: React.FC<PickIconModalProps> = ({navigation}) => {
+  const [selectedIcon, setSelectedIcon] = useState('');
+
+  const onIconPress = (icon: string) => {
+    setSelectedIcon(icon);
+  };
+
+  const onSelectIcon = () => {
+    navigation.navigate(LABEL.HABITS_STACK, {
+      screen: LABEL.ADD_HABIT_MODAL,
+      params: {iconName: selectedIcon},
+    });
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.pop()}>
+          <MaterialIcons name="close" size={24} color="black" />
+        </TouchableOpacity>
+        <Text variant="titleMedium">Pick Icon</Text>
+        <TouchableOpacity onPress={onSelectIcon}>
+          <Text style={styles.select}>Select</Text>
+        </TouchableOpacity>
+      </View>
+      <View style={styles.iconContainer}>
+        {icons.map((icon, index) => (
+          <TouchableOpacity
+            key={index}
+            onPress={() => onIconPress(icon)}
+            style={[
+              styles.iconButton,
+              selectedIcon === icon && styles.iconButtonSelected,
+            ]}>
+            <MaterialCommunityIcons
+              name={icon}
+              size={24}
+              color={selectedIcon === icon ? 'white' : 'black'}
+            />
+          </TouchableOpacity>
+        ))}
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomColor: 'lightgray',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  select: {
+    fontSize: 16,
+    color: 'blue',
+  },
+  iconContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-evenly',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  iconButton: {
+    padding: 8,
+    backgroundColor: 'lightgray',
+    borderRadius: 5,
+    margin: 8,
+  },
+  iconButtonSelected: {
+    backgroundColor: 'blue',
+  },
+});

--- a/src/features/habits/components/AddHabit/WeekdayPicker.tsx
+++ b/src/features/habits/components/AddHabit/WeekdayPicker.tsx
@@ -47,6 +47,7 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    marginBottom: 16,
   },
   dayButton: {
     padding: 10,

--- a/src/features/habits/components/AddHabit/WeekdayPicker.tsx
+++ b/src/features/habits/components/AddHabit/WeekdayPicker.tsx
@@ -1,5 +1,6 @@
+import {themeColors} from '@app/theme';
 import React from 'react';
-import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {Text} from 'react-native-paper';
 
 const daysOfWeek = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
@@ -14,37 +15,49 @@ export const WeekdayPicker: React.FC<WeekdayPickerProps> = ({
   onDayPress,
 }) => {
   return (
-    <View style={styles.container}>
-      {daysOfWeek.map((day, index) => (
-        <TouchableOpacity
-          key={index}
-          style={[
-            styles.dayButton,
-            selectedDays[index] && styles.dayButtonSelected,
-          ]}
-          onPress={() => onDayPress(index)}>
-          <Text style={selectedDays[index] && styles.dayButtonTextSelected}>
-            {day}
-          </Text>
-        </TouchableOpacity>
-      ))}
-    </View>
+    <>
+      <Text style={styles.repeatLabel}>REPEAT</Text>
+      <View style={styles.container}>
+        {daysOfWeek.map((day, index) => (
+          <TouchableOpacity
+            key={index}
+            style={[
+              styles.dayButton,
+              selectedDays[index] && styles.dayButtonSelected,
+            ]}
+            onPress={() => onDayPress(index)}>
+            <Text style={selectedDays[index] && styles.dayButtonTextSelected}>
+              {day}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </>
   );
 };
 
 const styles = StyleSheet.create({
+  fence: {
+    paddingVertical: 12,
+  },
+  repeatLabel: {
+    marginLeft: 4,
+    marginBottom: 4,
+  },
   container: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: 16,
   },
   dayButton: {
-    padding: 8,
-    backgroundColor: 'lightgray',
-    borderRadius: 5,
+    padding: 10,
+    flex: 1,
+    marginHorizontal: 4,
+    alignItems: 'center',
+    backgroundColor: themeColors.grey[200],
+    borderRadius: 8,
   },
   dayButtonSelected: {
-    backgroundColor: 'blue',
+    backgroundColor: themeColors.primary,
   },
   dayButtonTextSelected: {
     color: 'white',

--- a/src/features/habits/components/AddHabit/WeekdayPicker.tsx
+++ b/src/features/habits/components/AddHabit/WeekdayPicker.tsx
@@ -1,9 +1,10 @@
+import {LABEL} from '@app/language';
 import {themeColors} from '@app/theme';
 import React from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {Text} from 'react-native-paper';
 
-const daysOfWeek = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+const daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 interface WeekdayPickerProps {
   selectedDays: boolean[];
@@ -16,7 +17,9 @@ export const WeekdayPicker: React.FC<WeekdayPickerProps> = ({
 }) => {
   return (
     <>
-      <Text style={styles.repeatLabel}>REPEAT</Text>
+      <Text variant="labelMedium" style={styles.repeatLabel}>
+        {LABEL.REPEAT}
+      </Text>
       <View style={styles.container}>
         {daysOfWeek.map((day, index) => (
           <TouchableOpacity
@@ -26,7 +29,12 @@ export const WeekdayPicker: React.FC<WeekdayPickerProps> = ({
               selectedDays[index] && styles.dayButtonSelected,
             ]}
             onPress={() => onDayPress(index)}>
-            <Text style={selectedDays[index] && styles.dayButtonTextSelected}>
+            <Text
+              variant="labelSmall"
+              style={[
+                styles.dayButtonText,
+                selectedDays[index] && styles.dayButtonTextSelected,
+              ]}>
               {day}
             </Text>
           </TouchableOpacity>
@@ -42,7 +50,8 @@ const styles = StyleSheet.create({
   },
   repeatLabel: {
     marginLeft: 4,
-    marginBottom: 4,
+    marginBottom: 8,
+    fontWeight: '300',
   },
   container: {
     flexDirection: 'row',
@@ -50,17 +59,23 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   dayButton: {
-    padding: 10,
+    borderWidth: 1.5,
+    borderColor: themeColors.grey[400],
+    paddingVertical: 11,
     flex: 1,
     marginHorizontal: 4,
     alignItems: 'center',
-    backgroundColor: themeColors.grey[200],
+    // backgroundColor: themeColors.grey[200],
     borderRadius: 8,
   },
   dayButtonSelected: {
-    backgroundColor: themeColors.primary,
+    borderColor: themeColors.primary,
+    backgroundColor: themeColors.primaryContainer,
+  },
+  dayButtonText: {
+    color: themeColors.grey[600],
   },
   dayButtonTextSelected: {
-    color: 'white',
+    color: themeColors.primary,
   },
 });

--- a/src/features/habits/components/AddHabit/WeekdayPicker.tsx
+++ b/src/features/habits/components/AddHabit/WeekdayPicker.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {StyleSheet, View, TouchableOpacity} from 'react-native';
+import {Text} from 'react-native-paper';
+
+const daysOfWeek = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+interface WeekdayPickerProps {
+  selectedDays: boolean[];
+  onDayPress: (index: number) => void;
+}
+
+export const WeekdayPicker: React.FC<WeekdayPickerProps> = ({
+  selectedDays,
+  onDayPress,
+}) => {
+  return (
+    <View style={styles.container}>
+      {daysOfWeek.map((day, index) => (
+        <TouchableOpacity
+          key={index}
+          style={[
+            styles.dayButton,
+            selectedDays[index] && styles.dayButtonSelected,
+          ]}
+          onPress={() => onDayPress(index)}>
+          <Text style={selectedDays[index] && styles.dayButtonTextSelected}>
+            {day}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  dayButton: {
+    padding: 8,
+    backgroundColor: 'lightgray',
+    borderRadius: 5,
+  },
+  dayButtonSelected: {
+    backgroundColor: 'blue',
+  },
+  dayButtonTextSelected: {
+    color: 'white',
+  },
+});

--- a/src/features/habits/components/AddHabitModal.tsx
+++ b/src/features/habits/components/AddHabitModal.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {StyleSheet, Text, View, TouchableOpacity} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
+
+interface AddHabitModalProps {
+  navigation: any;
+}
+
+export const AddHabitModal: React.FC<AddHabitModalProps> = ({navigation}) => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.pop()}>
+          <MaterialIcons name="close" size={24} color="black" />
+        </TouchableOpacity>
+        <Text style={styles.title}>Add Habit</Text>
+        <View style={{width: 24}} />
+      </View>
+      <View style={styles.content}>{/* Add content here */}</View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'white',
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderBottomColor: 'lightgray',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 18,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+});

--- a/src/features/habits/components/HabitsScreen.tsx
+++ b/src/features/habits/components/HabitsScreen.tsx
@@ -8,17 +8,17 @@ import {LABEL} from '@app/language';
 import {useStore} from '@app/context/StoreContext';
 import {Habit} from './Habit';
 import {themeColors} from '@app/theme';
-// import {AddHabit} from './AddHabit';
-// import {ShadowModal} from '@app/components/ShadowModal';
 
-export const HabitsScreen = () => {
+interface HabitScreenProps {
+  navigation: any;
+}
+
+export const HabitsScreen = ({navigation}: HabitScreenProps) => {
   const [habitsStatus, setHabitsStatus] = useState<'active' | 'archived'>(
     'active',
   );
   const {state} = useStore();
   const {habits} = state;
-
-  //   const [modalVisible, setModalVisible] = useState(false);
 
   const setActive = () => {
     setHabitsStatus('active');
@@ -34,12 +34,6 @@ export const HabitsScreen = () => {
         flex: 1,
       }}
       edges={['top', 'left', 'right']}>
-      {/* <ShadowModal
-        modalVisible={modalVisible}
-        setModalVisible={setModalVisible}>
-        <AddHabit setModalVisible={setModalVisible} />
-      </ShadowModal> */}
-
       <PaperView style={{flex: 1}}>
         <View style={styles.headerContainer}>
           <Text variant="headlineLarge" style={styles.heading}>
@@ -66,7 +60,7 @@ export const HabitsScreen = () => {
             <IconButton
               icon="plus"
               iconColor={themeColors.primary}
-              onPress={() => console.log('add habit pressed')}
+              onPress={() => navigation.navigate(LABEL.ADD_HABIT_MODAL)}
             />
           </View>
         </View>

--- a/src/features/habits/components/HabitsStack.tsx
+++ b/src/features/habits/components/HabitsStack.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
+
+import {HabitsScreen} from './HabitsScreen';
+import {AddHabitModal} from './AddHabitModal';
+import {LABEL} from '@app/language';
+
+const Stack = createStackNavigator();
+
+export const HabitsStack = () => {
+  return (
+    <Stack.Navigator
+      initialRouteName={LABEL.HABITS_SCREEN}
+      screenOptions={{
+        ...TransitionPresets.ModalPresentationIOS,
+        headerShown: false,
+        cardOverlayEnabled: true,
+        headerMode: 'screen',
+      }}>
+      <Stack.Screen name={LABEL.HABITS_SCREEN} component={HabitsScreen} />
+      <Stack.Screen
+        name={LABEL.ADD_HABIT_MODAL}
+        component={AddHabitModal}
+        options={() => ({
+          cardOverlayEnabled: true,
+          gestureDirection: 'vertical',
+        })}
+      />
+    </Stack.Navigator>
+  );
+};

--- a/src/features/habits/components/HabitsStack.tsx
+++ b/src/features/habits/components/HabitsStack.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 
 import {HabitsScreen} from './HabitsScreen';
-import {AddHabitModal} from './AddHabitModal';
+import {AddHabitModal} from './AddHabit/AddHabitModal';
 import {LABEL} from '@app/language';
 
 const Stack = createStackNavigator();
@@ -15,7 +15,6 @@ export const HabitsStack = () => {
         ...TransitionPresets.ModalPresentationIOS,
         headerShown: false,
         cardOverlayEnabled: true,
-        headerMode: 'screen',
       }}>
       <Stack.Screen name={LABEL.HABITS_SCREEN} component={HabitsScreen} />
       <Stack.Screen

--- a/src/features/habits/components/HabitsStack.tsx
+++ b/src/features/habits/components/HabitsStack.tsx
@@ -3,6 +3,7 @@ import {createStackNavigator, TransitionPresets} from '@react-navigation/stack';
 
 import {HabitsScreen} from './HabitsScreen';
 import {AddHabitModal} from './AddHabit/AddHabitModal';
+import {PickIconModal} from './AddHabit/PickIconModal';
 import {LABEL} from '@app/language';
 
 const Stack = createStackNavigator();
@@ -20,6 +21,14 @@ export const HabitsStack = () => {
       <Stack.Screen
         name={LABEL.ADD_HABIT_MODAL}
         component={AddHabitModal}
+        options={() => ({
+          cardOverlayEnabled: true,
+          gestureDirection: 'vertical',
+        })}
+      />
+      <Stack.Screen
+        name={LABEL.PICK_ICON_MODAL}
+        component={PickIconModal}
         options={() => ({
           cardOverlayEnabled: true,
           gestureDirection: 'vertical',

--- a/src/features/habits/index.tsx
+++ b/src/features/habits/index.tsx
@@ -1,1 +1,1 @@
-export * from './components/HabitsScreen';
+export * from './components/HabitsStack';

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -8,6 +8,8 @@ export const LABEL = {
   ALREADY_HAVE_ACCOUNT: 'I already have an account',
   TODAY: 'Today',
   TODAY_HEADER: "Today's Habits",
+  HABITS_STACK: 'Habits Stack',
+  ADD_HABIT_MODAL: 'Add Habit Modal',
   HABITS_SCREEN: 'Habits Screen',
   HABITS: 'Habits',
   HABITS_HEADER: 'My Habits',

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -17,4 +17,6 @@ export const LABEL = {
   ACTIVE: 'Active',
   ARCHIVED: 'Archived',
   DAYS_COMPLETED: (percentage: number) => `${percentage}% of days completed`,
+  HABIT_REQUIRED: 'Habit name is required.',
+  CHOOSE_ICON: 'Please choose an icon.',
 };

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -10,6 +10,7 @@ export const LABEL = {
   TODAY_HEADER: "Today's Habits",
   HABITS_STACK: 'Habits Stack',
   ADD_HABIT_MODAL: 'Add Habit Modal',
+  PICK_ICON_MODAL: 'Pick Icon Modal',
   HABITS_SCREEN: 'Habits Screen',
   HABITS: 'Habits',
   HABITS_HEADER: 'My Habits',

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -19,4 +19,9 @@ export const LABEL = {
   DAYS_COMPLETED: (percentage: number) => `${percentage}% of days completed`,
   HABIT_REQUIRED: 'Habit name is required.',
   CHOOSE_ICON: 'Please choose an icon.',
+  DISCARD: 'Discard',
+  CREATE: 'Create',
+  CREATE_HABIT: 'Create Habit',
+  HABIT_NAME: 'Habit Name',
+  REPEAT: 'REPEAT',
 };

--- a/src/routes/AppTabs.tsx
+++ b/src/routes/AppTabs.tsx
@@ -4,7 +4,7 @@ import MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import {ColorValue} from 'react-native';
 
 import {TodayScreen} from '@app/features/today';
-import {HabitsScreen} from '@app/features/habits';
+import {HabitsStack} from '@app/features/habits';
 import {LABEL} from '@app/language';
 import {useStore, ACTIONS} from '@app/context/StoreContext';
 import {getHabits} from './api/getHabits';
@@ -36,8 +36,8 @@ export const AppTabs = () => {
         }}
       />
       <Tab.Screen
-        name={LABEL.HABITS_SCREEN}
-        component={HabitsScreen}
+        name={LABEL.HABITS_STACK}
+        component={HabitsStack}
         options={{
           tabBarLabel: LABEL.HABITS,
           tabBarIcon: ({color}) => (


### PR DESCRIPTION
## What
* Implement the styled add habit modal
* Also add a placeholder select icon modal with 5 hardcoded icons for now
* Add newly created habit to local store
* Validate habit name and icon is selected
* Display appropriate error messages in form
* Edit weekdays for repeating habit

TODOS:
* Add conditional styling depending on ios vs android
* Make weekday buttons square

Closes #10 

## Why

## How

## Screenshots

<img width="250" alt="image" src="https://user-images.githubusercontent.com/64414639/234454053-6724b1ac-e51f-4290-8d45-0575e045c96f.png">

Placeholder select icon screen (to be implemented in the next ticket)

<img width="253" alt="image" src="https://user-images.githubusercontent.com/64414639/234454107-2c42f6e4-85e3-4bee-831f-4b345046c0f6.png">

<img width="258" alt="image" src="https://user-images.githubusercontent.com/64414639/234454310-33e0cbb9-ab39-4dd0-b552-206bcf3fd3a8.png">


## Checklist before requesting a review

- [x] The branch successfully builds and runs on both Android and iOS emulators locally & running CMD + B on XCode builds successfully
- [x] I have linked an existing issue to this PR under the **What** section above (e.g. "Closes #xx", not via the side panel)
- [ ] I have updated any relevant documentation
- [x] I have performed a self-review of my code
- [ ] I have added sufficient tests to cover the new code if required
- [x] I have added all necessary screenshots to demonstrate changes (mainly FE changes)
